### PR TITLE
docs: fix urls after transferring ownership

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './docs/html/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master", "fix_url_after_transfer"]
+    branches: ["master"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["master", "fix_url_after_transfer"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -35,7 +35,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: './docs/html/'
+          path: './docs/html/mail2beyond'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@main

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Mail2Beyond
 =========
 
-[![PyLint](https://github.com/jaredhendrickson13/mail2beyond/actions/workflows/pylint.yml/badge.svg)](https://github.com/jaredhendrickson13/mail2beyond/actions/workflows/pylint.yml)
-[![Unit Tests](https://github.com/jaredhendrickson13/mail2beyond/actions/workflows/unittest.yml/badge.svg)](https://github.com/jaredhendrickson13/mail2beyond/actions/workflows/unittest.yml/badge.svg)
+[![PyLint](https://github.com/soluna-studios/mail2beyond/actions/workflows/pylint.yml/badge.svg)](https://github.com/soluna-studios/mail2beyond/actions/workflows/pylint.yml)
+[![Unit Tests](https://github.com/soluna-studios/mail2beyond/actions/workflows/unittest.yml/badge.svg)](https://github.com/soluna-studios/mail2beyond/actions/workflows/unittest.yml/badge.svg)
 
 Mail2Beyond is a Python-based SMTP server designed to redirect incoming SMTP messages to upstream APIs such as
 Google Chat, Slack, or even your own API! This includes a command line interface (CLI) that can be used to run
@@ -46,5 +46,5 @@ Mappings define which SMTP messages use which connector. This checks if a specif
 regular expression. If a match is found, the message is sent using the connector specified in the mapping.
 
 ## Developer Documentation
-- [CLI Documentation](https://github.com/jaredhendrickson13/mail2beyond/blob/documentation/docs/CLI.md)
-- [Python Package Documentation](https://github.com/jaredhendrickson13/mail2beyond/blob/documentation/docs/PACKAGE.md)
+- [CLI Documentation](https://github.com/soluna-studios/mail2beyond/blob/master/docs/CLI.md)
+- [Python Package Documentation](https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,7 +14,7 @@ tool. The CLI allows you define listeners, connectors and mappings using a JSON 
 
 ## Configuration
 A configuration file must be written before `mail2beyond` is started. It may also be helpful to check out the 
-[examples on GitHub](https://github.com/jaredhendrickson13/mail2beyond/tree/master/examples/configs). Configuration 
+[examples on GitHub](https://github.com/soluna-studios/mail2beyond/tree/master/examples/configs). Configuration 
 requirements and options are:
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/docs/PACKAGE.md
+++ b/docs/PACKAGE.md
@@ -11,8 +11,8 @@ If you've used the Mail2Beyond CLI, you are likely already familiar with the con
 listeners. These components also apply to the Mail2Beyond Python package but are handled slightly differently than the
 CLI.
 
-You may also want to refer to the 
-[API Documentation](https://github.com/soluna-studios/mail2beyond/blob/master/docs/html/)
+You may refer to the 
+[API Documentation](https://soluna-studios.github.io/mail2beyond/)
 
 ### Defining Connector Objects
 Connectors are the component that redirects SMTP messages to a specific API or service. There are a handful of built-in

--- a/docs/PACKAGE.md
+++ b/docs/PACKAGE.md
@@ -3,7 +3,7 @@ Mail2Beyond Python Package Documentation
 Mail2Beyond is built upon a simple framework that allows developers to integrate Mail2Beyond into their own applications, 
 or extend the existing functionality by writing custom connector and parser modules. If you are just getting started, it
 is recommended to first familiarize yourself with the 
-[Mail2Beyond CLI](https://github.com/jaredhendrickson13/mail2beyond/blob/documentation/docs/CLI.md) as it is a great way to
+[Mail2Beyond CLI](https://github.com/soluna-studios/mail2beyond/blob/master/docs/CLI.md) as it is a great way to
 learn how the components work.
 
 ## Getting started
@@ -12,7 +12,7 @@ listeners. These components also apply to the Mail2Beyond Python package but are
 CLI.
 
 You may also want to refer to the 
-[API Documentation](https://github.com/jaredhendrickson13/mail2beyond/blob/documentation/docs/html/)
+[API Documentation](https://github.com/soluna-studios/mail2beyond/blob/master/docs/html/)
 
 ### Defining Connector Objects
 Connectors are the component that redirects SMTP messages to a specific API or service. There are a handful of built-in

--- a/docs/html/mail2beyond/framework.html
+++ b/docs/html/mail2beyond/framework.html
@@ -471,8 +471,8 @@ class Mapping:
                 the content body based on the email&#39;s content-type header or pass in your own custom parser class.
 
         See Also:
-            https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors
-            https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers
+            https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors
+            https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers
         &#34;&#34;&#34;
         # Assign required attributes
         self.pattern = pattern
@@ -2235,8 +2235,8 @@ but it is strongly recommended you pass in <code><a title="mail2beyond.parsers.a
 the content body based on the email's content-type header or pass in your own custom parser class.</dd>
 </dl>
 <p>See Also:
-<a href="https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors">https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors</a>
-<a href="https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers">https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers</a></p></div>
+<a href="https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors">https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors</a>
+<a href="https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers">https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers</a></p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2277,8 +2277,8 @@ the content body based on the email's content-type header or pass in your own cu
                 the content body based on the email&#39;s content-type header or pass in your own custom parser class.
 
         See Also:
-            https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors
-            https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers
+            https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors
+            https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers
         &#34;&#34;&#34;
         # Assign required attributes
         self.pattern = pattern

--- a/mail2beyond/framework.py
+++ b/mail2beyond/framework.py
@@ -442,8 +442,8 @@ class Mapping:
                 the content body based on the email's content-type header or pass in your own custom parser class.
 
         See Also:
-            https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors
-            https://github.com/jaredhendrickson13/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers
+            https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-connectors
+            https://github.com/soluna-studios/mail2beyond/blob/master/docs/PACKAGE.md#writing-custom-parsers
         """
         # Assign required attributes
         self.pattern = pattern

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml~=6.0
 pyOpenSSL~=22.0.0
 pylint~=2.14.5
 html2text~=2020.1.16
+pdoc3~=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     name='mail2beyond',
     author='Jared Hendrickson',
     author_email='jaredhendrickson13@gmail.com',
-    url="https://github.com/jaredhendrickson13/mail2beyond",
+    url="https://github.com/soluna-studios/mail2beyond",
     license="Apache-2.0",
     description="A Python based SMTP server package and CLI that redirects incoming SMTP messages to upstream APIs like"
                 " Google Chat, Slack and more!.",
@@ -55,5 +55,5 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6'
+    python_requires='>=3.8'
 )


### PR DESCRIPTION
- Fixes broken GitHub URLs caused by transferring ownership of the repo.